### PR TITLE
Update dask-image to version 0.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,12 +18,13 @@ build:
 
 requirements:
   build:
+    - python >=3.5
     - pip
-    - python
     - setuptools
+    - wheel
 
   run:
-    - python
+    - python >=3.5
     - dask >=0.16.1
     - numpy >=1.11.3
     - scipy >=0.19.1
@@ -37,8 +38,12 @@ test:
     - dask_image
 
   requires:
+    - flake8 >=3.4.1
     - pytest >=3.0.5
+    - pytest-flake8 >=0.8.1
+    - pytest-timeout >=1.0.0
     - scikit-image >=0.12.3,<0.17.0
+    - tifffile >=2018.10.18
 
   commands:
     - pytest
@@ -46,6 +51,7 @@ test:
 about:
   home: https://github.com/dask/dask-image
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
   summary: Distributed image processing
   doc_url: https://dask-image.readthedocs.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   noarch: python
   number: 0
+  skip: True  # [py<35]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -44,9 +45,12 @@ test:
     - pytest-timeout >=1.0.0
     - scikit-image >=0.12.3,<0.17.0
     - tifffile >=2018.10.18
+    - pip
+    - python <3.10
 
   commands:
     - pytest
+    - pip check
 
 about:
   home: https://github.com/dask/dask-image

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,8 @@ source:
 build:
   noarch: python
   number: 0
-  # skip s390x due to missing scikit-image dependency version='>=0.12.3,<0.17.0
-  skip: True  # [py<35 or s390x]
+  # skip s390x osx-arm64 and linux-aarch64 due to missing scikit-image dependency version='>=0.12.3,<0.17.0
+  skip: True  # [py<35 or s390x or osx-arm64 or linux-aarch64]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   build:
-    - python >=3.5
+    - python
     - pip
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dask-image" %}
-{% set version = "0.4.0" %}
-{% set sha256 = "a6873a39af21b856a4eb7efee6838e6897b1399f21ab9e65403e69eb62f96c2d" %}
+{% set version = "0.6.0" %}
+{% set sha256 = "fee64c7fb5b2d2e27bdf250fea59bb5382496d94971c3bbf3ab68b52d7cefdff" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   noarch: python
   number: 0
   # skip s390x osx-arm64 and linux-aarch64 due to missing scikit-image dependency version='>=0.12.3,<0.17.0
-  skip: True  # [py<35 or s390x or osx-arm64 or linux-aarch64]
+  skip: True  # [py<35 or s390x or arm64 or aarch64]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ source:
 build:
   noarch: python
   number: 0
-  skip: True  # [py<35]
+  # skip s390x due to missing scikit-image dependency version='>=0.12.3,<0.17.0
+  skip: True  # [py<35 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
1. check the upstream
https://github.com/dask/dask-image/tree/v0.6.0

2. check the pinnings
https://github.com/dask/dask-image/blob/v0.6.0/setup.py
https://github.com/dask/dask-image/blob/v0.6.0/environment_doc.yml

Python 3.5 is specified on the setup.py file
https://github.com/dask/dask-image/blob/v0.6.0/setup.py#L74

3. check changelogs
https://github.com/dask/dask-image/releases/tag/v0.6.0

The changes mentioned were new features improvements and bug fixes and 

New Features
- GPU support for ndmorph subpackage: binary morphological functions (`#157`)

Improvements
- Improve imread performance: reduced overhead of pim.open calls when reading from image sequence (`#182`)

Bug Fixes
- dask-image imread v0.5.0 not working with dask distributed Client & napari (`#194`)
- Not able to map actual image name with dask_image.imread (#200, fixed by `#182`)
- affine_transform: Remove inconsistencies with ndimage implementation `#205`

4. additional research
https://github.com/conda-forge/dask-image-feedstock/issues

there are no open issues at the time of the review

5. verify dev_url
dev_url: https://github.com/dask/dask-image

6. verify doc_url
doc_url: https://dask-image.readthedocs.io/

7. verify that pip is in the test section
8. verify the test section
9. additional tests

In order to test the `dask-image` package version `0.6.0` the following command was used:
`conda build dask-image-feedstock --test` 
The test result was the following:
`All tests passed`

Since there are no packages depending on `dask-image 0.6.0` no import test were conducted.

Based on the research findings and on the test results we can conclude that it is safe to update `dask-image` to version `0.6.0`
