### PR TITLE
dask-image 2024.5.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/pims-feedstock/pr1/1cf6cfd

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/pims-feedstock/pr1/1cf6cfd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
   run:
     - python
     - dask-core >=2024.4.1
+    - dask >=2024.4.1
     - numpy >=1.18
     - scipy >=1.7.0
     - pims >=0.4.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,7 @@ about:
   license_family: BSD
   license_file: LICENSE.txt
   summary: Distributed image processing
+  description: Image processing with Dask Arrays
   doc_url: https://image.dask.org/
   dev_url: https://github.com/dask/dask-image
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - wheel
   run:
     - python
-    - dask-core >=2023.2.0
+    - dask-core >=2024.4.1
     - numpy >=1.18
     - scipy >=0.19.1
     - pims >=0.4.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,8 @@ requirements:
   run:
     - python
     - dask-core >=2024.4.1
-    - numpy >=1.18
+    # Tests fail without numpy upper bound
+    - numpy >=1.18,<2.0
     - scipy >=1.7.0
     - pims >=0.4.1
     - tifffile >=2018.10.18
@@ -43,8 +44,7 @@ test:
     - pip
     - python
   commands:
-    # AttributeError: `ptp` was removed from the ndarray class in NumPy 2.0
-    - pytest tests -v -k "not(test_rotate_minimal_input or test_rotate_type_consistency or test_rotate_no_chunks_specified or test_rotate_prefilter_not_implemented_error)"
+    - pytest tests -v
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - python
     - dask-core >=2024.4.1
     - numpy >=1.18
-    - scipy >=0.19.1
+    - scipy >=1.7.0
     - pims >=0.4.1
     - tifffile >=2018.10.18
     - pandas >=2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
   run:
     - python
     - dask-core >=2024.4.1
-    - dask >=2024.4.1
     - numpy >=1.18
     - scipy >=1.7.0
     - pims >=0.4.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - python
     - dask-core >=2024.4.1
     # Tests fail without numpy upper bound
+    # https://github.com/dask/dask-image/issues/392
     - numpy >=1.18,<2.0
     - scipy >=1.7.0
     - pims >=0.4.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,9 +40,7 @@ test:
     - dask_image
   requires:
     - pytest >=3.0.5
-    - pytest-timeout >=1.0.0
     - pip
-    - python
   commands:
     - pytest tests -v
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 0
   skip: True  # [py<39]
   script:
-    - cp {{ RECIPE_DIR }}/versioneer.py {{ SRC_DIR }}/
+    # - cp {{ RECIPE_DIR }}/versioneer.py {{ SRC_DIR }}/
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -38,12 +38,12 @@ test:
   imports:
     - dask_image
   requires:
-    - pytest >=7.2.2
-    - pytest-timeout >=2.3.1
+    - pytest >=3.0.5
+    - pytest-timeout >=1.0.0
     - pip
     - python
   commands:
-    - pytest tests -v
+    - pytest
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - setuptools_scm
   run:
     - python
     - dask-core >=2024.4.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,20 @@
 {% set name = "dask-image" %}
-{% set version = "2023.8.1" %}
-{% set sha256 = "5e9a8985b0527a1b5942c6a7e744e0e57d264e222c7058f05baeb81c374d04b6" %}
+{% set version = "2024.5.3" %}
+{% set sha256 = "0c9f1fdf0215800aada7a706ae6d263f5995fe1dbf87b657f797ca1dec48823c" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: 0
   skip: True  # [py<39]
-  script: 
-    - cp {{ RECIPE_DIR }}/versioneer.py {{ SRC_DIR }}/ 
+  script:
+    - cp {{ RECIPE_DIR }}/versioneer.py {{ SRC_DIR }}/
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,9 @@ test:
     - dask_image
   requires:
     - pytest >=3.0.5
+    - pytest-timeout >=1.0.0
     - pip
+    - python
   commands:
     - pytest tests -v
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,8 @@ test:
     - pip
     - python
   commands:
-    - pytest tests -v
+    # AttributeError: `ptp` was removed from the ndarray class in NumPy 2.0
+    - pytest tests -v -k "not(test_rotate_minimal_input or test_rotate_type_consistency or test_rotate_no_chunks_specified or test_rotate_prefilter_not_implemented_error)"
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,11 +38,9 @@ test:
     - dask_image
   requires:
     - pytest >=3.0.5
-    - pytest-timeout >=1.0.0
     - pip
-    - python
   commands:
-    - pytest
+    - pytest tests -v
     - pip check
 
 about:
@@ -58,3 +56,4 @@ extra:
   recipe-maintainers:
     - GenevieveBuckley
     - jakirkham
+    - m-albert

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ build:
   number: 0
   skip: True  # [py<39]
   script:
-    # - cp {{ RECIPE_DIR }}/versioneer.py {{ SRC_DIR }}/
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,12 @@ test:
   imports:
     - dask_image
   requires:
-    - pytest >=3.0.5
-    - pytest-timeout >=1.0.0
+    - pytest >=7.2.2
+    - pytest-timeout >=2.3.1
     - pip
     - python
   commands:
-    - pytest
+    - pytest tests -v
     - pip check
 
 about:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6843](https://anaconda.atlassian.net/browse/PKG-6843)
- [Upstream repository](https://github.com/dask/dask-image/tree/v2024.5.3)
- [Upstream changelog/diff](https://github.com/dask/dask-image/releases)

### Explanation of changes:

- Set version and sha
- Update run and test dependencies
- Remove outdated `versioneer.py` hack
- Add `numpy` upper bound so tests don't fail (and since dask-image isn't compatible with `numpy 2.0`)

[PKG-6843]: https://anaconda.atlassian.net/browse/PKG-6843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ